### PR TITLE
Update KeySharesPayloadV3.ts

### DIFF
--- a/src/lib/KeyShares/KeySharesData/KeySharesPayloadV3.ts
+++ b/src/lib/KeyShares/KeySharesData/KeySharesPayloadV3.ts
@@ -23,8 +23,8 @@ export class KeySharesPayloadV3 implements IKeySharesPayload {
 
   private sharesToBytes(publicKeys: string[], privateKeys: string[]): string {
     const encryptedShares = this.decodeRSAShares([...privateKeys]);
-    const arrayPublicKeys = new Uint8Array(publicKeys.map(pk => [...ethers.utils.arrayify(pk)]).flat());
-    const arrayEncryptedShares = new Uint8Array(encryptedShares.map(sh => [...ethers.utils.arrayify(sh)]).flat());
+    const arrayPublicKeys = Buffer.from(publicKeys.map(pk => [...ethers.utils.arrayify(pk)]).flat());
+    const arrayEncryptedShares = Buffer.from(encryptedShares.map(sh => [...ethers.utils.arrayify(sh)]).flat());
 
     // public keys hex encoded
     const pkHex = ethers.utils.hexlify(arrayPublicKeys);


### PR DESCRIPTION
Buffer.concat expects an array of Buffers, but we were passing it a uint8Array. this change corrects that.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
