### PR TITLE
feat: Add Linux ARM64 packaging support and refactor Linux build scri…

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "pre-commit": "pnpm run lint && pnpm run build-all",
     "build:ts": "tsc",
     "package-all": "pnpm run package-linux && pnpm run package-macos && pnpm run package-win",
-    "package-linux": "pkg dist/cli-interactive.js --targets node22-linux-x64 --output bin/linux/ssv-keys-lin --compress GZip",
+    "package-linux": "pnpm run package-linux-x64 && pnpm run package-linux-arm64",
+    "package-linux-x64": "pkg dist/cli-interactive.js --targets node22-linux-x64 --output bin/linux/ssv-keys-lin-x64 --compress GZip",
+    "package-linux-arm64": "pkg dist/cli-interactive.js --targets node22-linux-arm64 --output bin/linux/ssv-keys-lin-arm64 --compress GZip",
     "package-macos": "pkg dist/cli-interactive.js --targets node22-macos-x64 --output bin/macos/ssv-keys-mac --compress GZip",
     "package-win": "pnpm build && pkg dist/cli-interactive.js --targets node22-win-x64 --output bin/win/ssv-keys.exe --compress GZip"
   },


### PR DESCRIPTION
## Summary
This PR introduces support for building and releasing the CLI for Linux ARM64 architecture.

## Why is this needed?
- **Broadens specific hardware support:** Enables users to run `ssv-keys` natively on ARM-based Linux devices such as Raspberry Pi, Rock5B, OrangePi, AWS Graviton instances, and other ARM servers.
- **Performance:** Native binaries provide better performance compared to running x64 binaries via emulation.

## Changes
- **`package.json`**:
  - Split `package-linux` into `package-linux-x64` and `package-linux-arm64`.
  - Updated `package-linux` to execute both build targets.
- **Artifact Naming**:
  - Renamed the x64 binary from `ssv-keys-lin` to `ssv-keys-lin-x64` for consistency.
  - New ARM64 binary is named `ssv-keys-lin-arm64`.

## Verification
- Verified locally that both binaries are generated successfully.
- Confirmed file architectures using the `file` command:
  - `ssv-keys-lin-x64`: ELF 64-bit LSB executable, x86-64
  - `ssv-keys-lin-arm64`: ELF 64-bit LSB pie executable, ARM aarch64
