### PR TITLE
chore(ci) - Update actions base image to node:24

### DIFF
--- a/.github/workflows/build-and-release-linux.yml
+++ b/.github/workflows/build-and-release-linux.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v6.0.2 # v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        uses: pnpm/action-setup@v5.0.0 # v4
         with:
           version: latest
 
       - name: Install Node.js and pnpm
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@v6.3.0 # v4
         with:
           node-version: '22.x'
           cache: 'pnpm'
@@ -51,7 +51,7 @@ jobs:
 
       - name: Release assets
         if: ${{ startsWith(matrix.os, 'ubuntu') && startsWith(github.ref, 'refs/tags/v') }}
-        uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1
+        uses: ncipollo/release-action@v1.21.0 # v1
         with:
           draft: true
           allowUpdates: true

--- a/.github/workflows/build-and-release-mac.yml
+++ b/.github/workflows/build-and-release-mac.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v6.0.2 # v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        uses: pnpm/action-setup@v5.0.0 # v4
         with:
           version: latest
 
       - name: Install Node.js and pnpm
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@v6.3.0 # v4
         with:
           node-version: '22.x'
           cache: 'pnpm'
@@ -50,7 +50,7 @@ jobs:
 
       - name: Release assets
         if: ${{ startsWith(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags/v') }}
-        uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1
+        uses: ncipollo/release-action@v1.21.0 # v1
         with:
           draft: true
           allowUpdates: true

--- a/.github/workflows/build-and-release-win.yml
+++ b/.github/workflows/build-and-release-win.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v6.0.2 # v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        uses: pnpm/action-setup@v5.0.0 # v4
         with:
           version: latest
 
       - name: Install Node.js and pnpm
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@v6.3.0 # v4
         with:
           node-version: '22.x'
           cache: 'pnpm'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Release assets
         if: ${{ startsWith(matrix.os, 'windows') && startsWith(github.ref, 'refs/tags/v') }}
-        uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1
+        uses: ncipollo/release-action@v1.21.0 # v1
         with:
           draft: true
           allowUpdates: true


### PR DESCRIPTION
## Summary
GitHub is enforcing Node.js 24 for GitHub Actions runtime and will block workflows that rely on older Node runtimes.

This PR updates CI workflows to align with the requirement.

## Changes
- Update reusable action references (`uses:`) to latest released versions.
- Update workflow Node container images (`node:<version>`) to `node:24` where they were below 24.